### PR TITLE
Adding support for dynamic messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ grunt.initConfig({
 
     options: {
       authToken: "", // Create an authToken at https://hipchat.com/admin/api
-      roomId: "", // Numeric Hipchat roomId
+      roomId: "" // Numeric Hipchat roomId
     },
 
     // Now create as many messages as you like!
@@ -38,10 +38,28 @@ grunt.initConfig({
     hello_grunt: {
       options: {
         message: "Hello!", // A message to send
-        from: "Grunt" // Name for the sender
+        from: "Grunt", // Name for the sender
         color: "purple" // Color of the message
       }
     },
+
+    // Send dynamic message based off anything Node/Grunt/Javascript can do!
+    
+    dynamic_hello_grunt: {
+      options: {
+        message: function() { // Functions must return a string
+          var pkg = grunt.config.data.pkg;
+          return 'Running grunt on ' + pkg.name + ' on version ' + pkg.name;
+        },
+        from: function() {  // Return the run-time user, or something more creative.
+          return someUsernameGenerator() || process.env['USER'];
+        },
+        // Change color dynamically based on some global state, function response, etc
+        color: function() {
+          return (grunt.config.data.someBoolean && allIsWell()) ? 'green' : 'red';
+        }
+      }
+    }
 
   },
 })
@@ -49,6 +67,7 @@ grunt.initConfig({
 
 ## Release History
 
+* 0.1.1 - Added support for dynamic messaging
 * 0.1.0 - First release
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-hipchat-notifier",
   "description": "Send grunt messages to a Hipchat channel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/logankoester/grunt-hipchat-notifier",
   "author": {
     "name": "Logan Koester",

--- a/src/tasks/hipchat_notifier.coffee
+++ b/src/tasks/hipchat_notifier.coffee
@@ -28,10 +28,10 @@ module.exports = (grunt) ->
     grunt.log.writeln 'Sending Hipchat notification...'
 
     params =
-      from: options.from
-      color: options.color
+      from: options.from?() ? options.from
+      color: options.color?() ? options.color
       notify: options.notify
 
-    hipchat.sendRoomMessage options.message, options.roomId, params, (success) ->
+    hipchat.sendRoomMessage options.message?() ? options.message, options.roomId, params, (success) ->
       grunt.log.writeln 'Notification sent!'
       done()

--- a/tasks/hipchat_notifier.js
+++ b/tasks/hipchat_notifier.js
@@ -3,7 +3,7 @@
     var HipchatClient;
     HipchatClient = require('hipchat-client');
     return grunt.registerMultiTask('hipchat_notifier', 'Send a message to a Hipchat room', function() {
-      var done, hipchat, options, params;
+      var done, hipchat, options, params, _ref, _ref1, _ref2;
       grunt.config.requires('hipchat_notifier.options.authToken');
       grunt.config.requires('hipchat_notifier.options.roomId');
       options = this.options({
@@ -18,11 +18,11 @@
       grunt.verbose.writeln("Room: " + options.room);
       grunt.log.writeln('Sending Hipchat notification...');
       params = {
-        from: options.from,
-        color: options.color,
+        from: (_ref = typeof options.from === "function" ? options.from() : void 0) != null ? _ref : options.from,
+        color: (_ref1 = typeof options.color === "function" ? options.color() : void 0) != null ? _ref1 : options.color,
         notify: options.notify
       };
-      return hipchat.sendRoomMessage(options.message, options.roomId, params, function(success) {
+      return hipchat.sendRoomMessage((_ref2 = typeof options.message === "function" ? options.message() : void 0) != null ? _ref2 : options.message, options.roomId, params, function(success) {
         grunt.log.writeln('Notification sent!');
         return done();
       });


### PR DESCRIPTION
By allowing the message, from, and color options to be functions (as an alternative to strings), the functions are executed just before sendRoomMessage is executed. This allows the messages to dynamically change based of Grunt/repo state.

As an example, I use grunt to publish packages to an internal NPM repository and we can now send HipChat messages that contain the repo name, package name, git user.email (whodunnit), package version, commit, etc, along with links (to GitHub, CI build, etc) into our Deploy HipChat Room for the whole team to see! It's awesome :)
