### PR TITLE
Adds in support for message_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ grunt.initConfig({
         message: "Hello!", // A message to send
         from: "Grunt", // Name for the sender
         color: "purple" // Color of the message
+        message_format: "text" // Can either be 'text' or 'html' format
       }
     },
 
@@ -72,7 +73,7 @@ grunt.initConfig({
 ```
 
 ## Release History
-
+* 0.1.2 - Added support for Hipchat message type to allow for emoticons and @mentions
 * 0.1.1 - Added support for dynamic messaging
 * 0.1.0 - First release
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ grunt.initConfig({
         message: "Hello!", // A message to send
         from: "Grunt", // Name for the sender
         color: "purple" // Color of the message
-        message_format: "text" // Can either be 'text' or 'html' format
+        message_format: "html" // Can either be 'text' or 'html' format
       }
     },
 
@@ -73,7 +73,7 @@ grunt.initConfig({
 ```
 
 ## Release History
-* 0.1.2 - Added support for Hipchat message type to allow for emoticons and @mentions
+* 0.2.0 - Added support for Hipchat message_format to allow for emoticons and @mentions
 * 0.1.1 - Added support for dynamic messaging
 * 0.1.0 - First release
 

--- a/src/tasks/hipchat_notifier.coffee
+++ b/src/tasks/hipchat_notifier.coffee
@@ -16,6 +16,7 @@ module.exports = (grunt) ->
       from: 'GruntJS'
       color: 'yellow'
       notify: 0
+      message_format: 'html'
     )
 
     grunt.verbose.writeflags options, 'Options'
@@ -31,6 +32,7 @@ module.exports = (grunt) ->
       from: options.from?() ? options.from
       color: options.color?() ? options.color
       notify: options.notify
+      message_format: options.message_format
 
     hipchat.sendRoomMessage options.message?() ? options.message, options.roomId, params, (success) ->
       grunt.log.writeln 'Notification sent!'


### PR DESCRIPTION
This adds in support for a new option, `message_format`, which can either be set to `text` or `html`. See here for more info: https://www.hipchat.com/docs/api/method/rooms/message
